### PR TITLE
fix(vs-testcase): run command did not copy

### DIFF
--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -58,8 +58,7 @@ jobs:
           cd tests
           . /usr/share/modules/init/sh
           module use /opt/modules
-          module add questasim 
-          module add vesyla
+          module add questasim
           module add bender
           module add sst
           python3 -m venv .venv

--- a/modules/vs-testcase/src/main.rs
+++ b/modules/vs-testcase/src/main.rs
@@ -268,6 +268,7 @@ fn run(
 
     // run the testcase, if the testcase fails, the process will exit with non-zero status
     info!("Copying and running testcase in {:?}", temp_dir_path);
+    copy_dir_all(test_dir, temp_dir_path).expect("Failed to copy testcase directory");
     let testcase_script_path = format!("{}/run.sh", temp_dir_path.display());
     let status = process::Command::new("sh")
         .arg(testcase_script_path)


### PR DESCRIPTION
# fix(vs-testcase): run command did not copy

## Description

Fixed the run command not copying the testcase folder

### Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
## How Has This Been Tested?

- Tested locally

**Test Configuration**:

- OS: Ubuntu 22.04
- [drra-components](https://github.com/silagokth/drra-components): latest

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
