### PR TITLE
fix(vs-testcase): changed template script to run with bash; added spinner

### DIFF
--- a/modules/vs-testcase/src/main.rs
+++ b/modules/vs-testcase/src/main.rs
@@ -270,7 +270,7 @@ fn run(
     info!("Copying and running testcase in {:?}", temp_dir_path);
     copy_dir_all(test_dir, temp_dir_path).expect("Failed to copy testcase directory");
     let testcase_script_path = format!("{}/run.sh", temp_dir_path.display());
-    let status = process::Command::new("sh")
+    let status = process::Command::new("bash")
         .arg(testcase_script_path)
         .status()
         .expect("Failed to run the testcase");

--- a/modules/vs-testcase/template/drra/run.sh
+++ b/modules/vs-testcase/template/drra/run.sh
@@ -62,7 +62,7 @@ cleanup() {
   exit $exit_code
 }
 
-trap 'cleanup $1' INT TERM
+trap 'cleanup $?' INT TERM
 
 # Variables
 interactive_mode=false

--- a/modules/vs-testcase/template/drra/run.sh
+++ b/modules/vs-testcase/template/drra/run.sh
@@ -33,13 +33,13 @@ spin_animation() {
 }
 
 start_spinner() {
-  if [ $debug_mode = false ]; then
+  if [ "$debug_mode" = false ]; then
     spin_animation
   fi
 }
 
 stop_spinner() {
-  if [ $debug_mode = true ]; then
+  if [ "$debug_mode" = true ]; then
     printf "\n"
     return 0 # If debug mode is enabled, do not stop the spinner
   fi

--- a/modules/vs-testcase/template/drra/run.sh
+++ b/modules/vs-testcase/template/drra/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -23,19 +23,19 @@ for arg in "$@"; do
   case "$arg" in
   -it | --interactive | -it=all | --interactive=all)
     interactive_mode=all
-    echo "${CYAN}INFO:${NC} Interactive mode enabled for SST and RTL"
+    echo -e "${CYAN}INFO:${NC} Interactive mode enabled for SST and RTL"
     ;;
   -it=sst | --interactive=sst)
     interactive_mode=sst
-    echo "${CYAN}INFO:${NC} Interactive mode enabled for SST"
+    echo -e "${CYAN}INFO:${NC} Interactive mode enabled for SST"
     ;;
   -it=rtl | --interactive=rtl)
     interactive_mode=rtl
-    echo "${CYAN}INFO:${NC} Interactive mode enabled for RTL"
+    echo -e "${CYAN}INFO:${NC} Interactive mode enabled for RTL"
     ;;
   -d | --debug)
     debug_mode=true
-    echo "${CYAN}INFO:${NC} Debug mode enabled"
+    echo -e "${CYAN}INFO:${NC} Debug mode enabled"
     ;;
   -nc | --no-color)
     RED=''
@@ -69,8 +69,8 @@ run_and_check() {
   status=$?
   set -e
   if [ $status -ne 0 ]; then
-    echo " ${RED}-> ERROR:${NC} $desc failed!"
-    echo "${RED}Error details:${NC}"
+    echo -e " ${RED}-> ERROR:${NC} $desc failed!"
+    echo -e "${RED}Error details:${NC}"
     echo "$output"
     exit 1
   fi
@@ -83,113 +83,113 @@ cd ${template_path}/work
 mkdir -p mem
 
 # Assemble the fabric
-echo -n "${BOLD}Assembling the fabric${NC}"
+echo -n -e "${BOLD}Assembling the fabric${NC}"
 if [ "$debug_mode" = true ]; then
   bash ${template_path}/scripts/assemble.sh
 else
   run_and_check "Assembly" bash ${template_path}/scripts/assemble.sh
 fi
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 # Model 0
-echo "${BOLD}Model 0:${NC} C++ implementation"
+echo -e "${BOLD}Model 0:${NC} C++ implementation"
 ## Compile
-echo -n "\t${BLUE}Compiling${NC}"
+echo -n -e "\t${BLUE}Compiling${NC}"
 run_and_check "Compilation" g++ -g -I${template_path}/model_0/include -o run_model_0 ${template_path}/model_0/main.cpp ${template_path}/model_0/src/Drra.cpp ${template_path}/model_0/src/Util.cpp
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 ## Run
-echo -n "\t${BLUE}Running${NC}"
+echo -n -e "\t${BLUE}Running${NC}"
 ./run_model_0
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 ## Check that the output exists
-echo -n "\t${BLUE}Verifying${NC} (mem/sram_image_m0.bin)"
+echo -n -e "\t${BLUE}Verifying${NC} (mem/sram_image_m0.bin)"
 if [ ! -f "mem/sram_image_m0.bin" ]; then
-  echo " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin not found!"
+  echo -e " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin not found!"
   exit 1
 fi
 ## Check that the output is not empty
 if [ ! -s "mem/sram_image_m0.bin" ]; then
-  echo " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin is empty!"
+  echo -e " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin is empty!"
   exit 1
 fi
 sort -n mem/sram_image_m0.bin -o mem/sram_image_m0.bin
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 # Model 1
-echo "${YELLOW}Warning:${NC} Model 1 is not implemented yet. Skipping..."
+echo -e "${YELLOW}Warning:${NC} Model 1 is not implemented yet. Skipping..."
 cp mem/sram_image_m0.bin mem/sram_image_m1.bin
 
 # Model 2
-echo "${BOLD}Model 2:${NC} instruction-level simulation"
+echo -e "${BOLD}Model 2:${NC} instruction-level simulation"
 ## Compile
-echo -n "\t${BLUE}Compiling${NC}"
+echo -n -e "\t${BLUE}Compiling${NC}"
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 if [ "$debug_mode" = true ]; then
   bash ${template_path}/scripts/compile.sh ${template_path}/pasm
 else
   run_and_check "Compilation" bash ${template_path}/scripts/compile.sh ${template_path}/pasm
 fi
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 ## Run
 if [ "$interactive_mode" = "all" ] || [ "$interactive_mode" = "sst" ]; then
-  echo "\t${YELLOW}Warning:${NC} SST interactive mode is not implemented yet.\n\tRunning in non-interactive mode..."
+  echo -e "\t${YELLOW}Warning:${NC} SST interactive mode is not implemented yet.\n\tRunning in non-interactive mode..."
 fi
-echo -n "\t${BLUE}Running${NC}"
+echo -n -e "\t${BLUE}Running${NC}"
 if [ "$debug_mode" = true ]; then
   bash ${template_path}/scripts/instr_sim.sh 0
 else
   run_and_check "Instruction-level simulation" bash ${template_path}/scripts/instr_sim.sh 0
 fi
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 ## Verify (compare to model 0 output)
-echo -n "\t${BLUE}Verifying${NC} (mem/sram_image_m2.bin)"
+echo -n -e "\t${BLUE}Verifying${NC} (mem/sram_image_m2.bin)"
 sort -n mem/sram_image_m2.bin -o mem/sram_image_m2.bin
 set +e
 error_output=$(diff -q mem/sram_image_m0.bin mem/sram_image_m2.bin 2>&1)
 if [ $? -ne 0 ]; then
-  echo " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin and mem/sram_image_m2.bin differ!"
-  echo "${RED}Error details:${NC}"
+  echo -e " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin and mem/sram_image_m2.bin differ!"
+  echo -e "${RED}Error details:${NC}"
   echo "$error_output"
   exit 1
 fi
 set -e
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 # Model 3
-echo "${BOLD}Model 3:${NC} RTL simulation"
+echo -e "${BOLD}Model 3:${NC} RTL simulation"
 ## Run
 if [ "$interactive_mode" = "all" ] || [ "$interactive_mode" = "rtl" ]; then
-  echo -n "\t${BLUE}Compiling & Running${NC} (interactive mode)"
+  echo -n -e "\t${BLUE}Compiling & Running${NC} (interactive mode)"
 else
-  echo -n "\t${BLUE}Compiling & Running${NC}"
+  echo -n -e "\t${BLUE}Compiling & Running${NC}"
 fi
 if [ "$debug_mode" = true ]; then
   bash ${template_path}/scripts/rtl_sim.sh 0 -it="$interactive_mode"
 else
   run_and_check "RTL simulation" bash ${template_path}/scripts/rtl_sim.sh 0 -it="$interactive_mode"
 fi
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
 ## Verify (compare to model 0 output)
-echo -n "\t${BLUE}Verifying${NC} (mem/sram_image_m3.bin)"
+echo -n -e "\t${BLUE}Verifying${NC} (mem/sram_image_m3.bin)"
 sed -i 's/^[ \t]*//' mem/sram_image_m3.bin             # Remove leading whitespace from the output file
 sort -n mem/sram_image_m3.bin -o mem/sram_image_m3.bin # Reorder the memory file
 set +e
 error_output=$(diff -q mem/sram_image_m0.bin mem/sram_image_m3.bin 2>&1)
 if [ $? -ne 0 ]; then
-  echo " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin and mem/sram_image_m3.bin differ!"
-  echo "${RED}Error details:${NC}"
+  echo -e " ${RED}-> ERROR:${NC} mem/sram_image_m0.bin and mem/sram_image_m3.bin differ!"
+  echo -e "${RED}Error details:${NC}"
   echo "$error_output"
   exit 1
 fi
 set -e
-echo " ${GREEN}-> OK${NC}"
+echo -e " ${GREEN}-> OK${NC}"
 
-echo "\n${GREEN}All models executed successfully!${NC}\n"
+echo -e "\n${GREEN}All models executed successfully!${NC}\n"
 
 cat <<"EOF"
                         ░█████████▒░

--- a/modules/vs-testcase/template/drra/run.sh
+++ b/modules/vs-testcase/template/drra/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ -z "$BASH_VERSION" ]; then
+  echo "This script requires bash to run. Please use bash to execute it."
+  exit 1
+fi
+
 set -e
 
 # Colors


### PR DESCRIPTION
# fix(vs-testcase): changed template script to run with bash; added spinner 

## Description

Changes to the `run.sh` script in the vs-testcase template:
- Added a spinner for running tasks
- Changed the shell to `bash` when running testcase `run.sh` script for better color compatibility

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally:
  - ran template manually `./run.sh`
  - drra-tests
    - ran with `vesyla testcase generate`
    - ran with `vesyla testcase run`
**Test Configuration**:

- OS: Ubuntu 22.04
- [drra-components](https://github.com/silagokth/drra-components): latest

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
