### PR TITLE
feat(ci): add branch tracking to drra-tests CI workflows

### DIFF
--- a/.github/workflows/ci-build-appimage.yml
+++ b/.github/workflows/ci-build-appimage.yml
@@ -6,6 +6,9 @@ on:
       version:
         description: "Version from the built vesyla appimage"
         value: ${{ jobs.build.outputs.version }}
+      branch:
+        description: "Current vesyla branch on which this workflow is running"
+        value: ${{ jobs.build.outputs.branch }}
 
 env:
   LLVM_SOURCE_PATH: ${{ github.workspace }}/llvm-project
@@ -43,6 +46,7 @@ jobs:
       LLVM_HOME: ${{ github.workspace }}/llvm-build
     outputs:
       version: ${{ steps.check-version.outputs.version }}
+      branch: ${{ steps.check-branch.outputs.branch }}
     steps:
       - name: Restore LLVM Cache
         uses: actions/cache@v4
@@ -61,6 +65,14 @@ jobs:
         with:
           path: ./vesyla-source
           clean: false
+
+      - name: Check branch name
+        id: check-branch
+        run: |
+          cd ${{ github.workspace }}/vesyla-source
+          branch=${{ github.head_ref || github.ref_name }}
+          echo "Current branch is $branch"
+          echo "branch=$branch" >> $GITHUB_OUTPUT
 
       - name: Build project
         run: |

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -16,3 +16,4 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.ci-build-vesyla.outputs.version }}
+      branch: ${{ needs.ci-build-vesyla.outputs.branch }}

--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -6,6 +6,9 @@ on:
       version:
         required: true
         type: string
+      branch:
+        type: string
+        default: 'master'
 
 jobs:
   run-tests:
@@ -40,6 +43,19 @@ jobs:
           path: tests
           ref: master
           token: ${{ secrets.DRRA_TESTS_PAT_VESYLA_READ_ONLY }}
+
+      - name: Check drra-tests branch
+        run: |
+          cd "${{ github.workspace }}/tests"
+          git fetch --all
+          if git show-ref --verify --quiet refs/remotes/origin/${{ inputs.branch }}; then
+            git checkout ${{ inputs.branch }}
+            echo "Switching to drra-tests@${{ inputs.branch }}"
+          else
+            echo "Using the drra-tests master branch"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.DRRA_TESTS_PAT_VESYLA_READ_ONLY }}
 
       - name: Get built vesyla artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# feat(ci): add branch tracking to drra-tests CI workflows

## Description

Similarly to https://github.com/silagokth/drra-components/pull/94, this will check for an existing branch in drra-tests with the same name as the PR branch. If it does not exist, it will use drra-tests@master.

### Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Tested in PR workflow: https://github.com/silagokth/vesyla/actions/runs/15761972754/job/44431141268?pr=92

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules