### PR TITLE
fix(vs-component): refactor temporary directory handling in utils.rs

### DIFF
--- a/modules/vs-component/src/utils.rs
+++ b/modules/vs-component/src/utils.rs
@@ -549,13 +549,15 @@ sources:
 
     #[test]
     fn test_get_rtl_files_from_library_not_found() {
-        let result = get_rtl_files_from_library(&"nonexistent_component".to_string(), None);
+        let tmp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+        let result =
+            get_rtl_files_from_library(&"nonexistent_component".to_string(), None, tmp_dir.path());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_get_arch_from_library() {
-        let temp_dir = tempdir()
+        let temp_dir = tempfile::tempdir()
             .expect("Failed to create temporary directory")
             .path()
             .to_owned();
@@ -566,7 +568,7 @@ sources:
 
     #[test]
     fn test_get_isa_from_library() {
-        let temp_dir = tempdir()
+        let temp_dir = tempfile::tempdir()
             .expect("Failed to create temporary directory")
             .path()
             .to_owned();
@@ -577,11 +579,9 @@ sources:
 
     #[test]
     fn test_get_rtl_files_from_library() {
-        let temp_dir = tempdir()
-            .expect("Failed to create temporary directory")
-            .path()
-            .to_owned();
-        let fake_library_path = create_fake_library(temp_dir.to_path_buf()).unwrap();
+        let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+        let temp_dir_path = temp_dir.path();
+        let fake_library_path = create_fake_library(temp_dir_path.to_path_buf()).unwrap();
         assert!(
             fake_library_path.exists(),
             "Temporary library path does not exist"
@@ -614,7 +614,11 @@ sources:
                 .exists(),
             "RTL file for dummy component does not exist"
         );
-        let result = get_rtl_files_from_library(&"dummy".to_string(), Some(&fake_library_path));
+        let result = get_rtl_files_from_library(
+            &"dummy".to_string(),
+            Some(&fake_library_path),
+            temp_dir_path,
+        );
         assert!(
             result.is_ok(),
             "RTL files retrieval failed: {:?}",

--- a/modules/vs-component/src/utils.rs
+++ b/modules/vs-component/src/utils.rs
@@ -553,28 +553,33 @@ sources:
         let result =
             get_rtl_files_from_library(&"nonexistent_component".to_string(), None, tmp_dir.path());
         assert!(result.is_err());
+        tmp_dir
+            .close()
+            .expect("Failed to close temporary directory");
     }
 
     #[test]
     fn test_get_arch_from_library() {
-        let temp_dir = tempfile::tempdir()
-            .expect("Failed to create temporary directory")
-            .path()
-            .to_owned();
-        let fake_library_path = create_fake_library(temp_dir.to_path_buf()).unwrap();
+        let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+        let temp_dir_path = temp_dir.path().to_owned();
+        let fake_library_path = create_fake_library(temp_dir_path).unwrap();
         let result = get_arch_from_library(&"dummy".to_string(), Some(&fake_library_path));
         assert!(result.is_ok());
+        temp_dir
+            .close()
+            .expect("Failed to close temporary directory");
     }
 
     #[test]
     fn test_get_isa_from_library() {
-        let temp_dir = tempfile::tempdir()
-            .expect("Failed to create temporary directory")
-            .path()
-            .to_owned();
-        let fake_library_path = create_fake_library(temp_dir.to_path_buf()).unwrap();
+        let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+        let temp_dir_path = temp_dir.path().to_owned();
+        let fake_library_path = create_fake_library(temp_dir_path).unwrap();
         let result = get_isa_from_library(&"dummy".to_string(), Some(&fake_library_path));
         assert!(result.is_ok());
+        temp_dir
+            .close()
+            .expect("Failed to close temporary directory");
     }
 
     #[test]
@@ -624,6 +629,9 @@ sources:
             "RTL files retrieval failed: {:?}",
             result.err()
         );
+        temp_dir
+            .close()
+            .expect("Failed to close temporary directory");
     }
 
     #[test]


### PR DESCRIPTION
# fix(vs-component): refactor temporary directory handling in utils.rs

## Description

Basically the `.to_owned()` (see [example](https://github.com/silagokth/vesyla/blob/e3aec84b6bd633d841c89f8a4daeeb9ece48152c/modules/vs-component/src/utils.rs#L272)) was probably the source of the lack of clean up of the temp folders. Now, these `to_owned()` calls are removed and we make sure of the removal by closing the temp_dir variabe (even if this is overkill).

Fixes #96

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested locally
- Tested in PR workflow

**Test Configuration**:

- OS: Ubuntu 22.04
- [drra-components](https://github.com/silagokth/drra-components): v2.6.1-1-g6d5952b
- Other experimental setup details: https://github.com/silagokth/drra-tests

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules