### PR TITLE
fix(vs-component): removed the cmake instruction to compile timing_model that does not exist anymore

### DIFF
--- a/modules/vs-component/template/CMakeLists.txt
+++ b/modules/vs-component/template/CMakeLists.txt
@@ -2,5 +2,4 @@ find_package(DRRAUtils REQUIRED)
 
 add_subdirectory(sst)
 
-cargo_build(${CMAKE_CURRENT_SOURCE_DIR}/timing_model)
 cargo_build(${CMAKE_CURRENT_SOURCE_DIR}/compile_util)


### PR DESCRIPTION
# fix(vs-component): removed the cmake instruction to compile timing_model that does not exist anymore

## Description

This pull request makes a minor update to the build configuration by removing the `cargo_build` command for the `timing_model` component from the `CMakeLists.txt` file. This change likely reflects that the `timing_model` is no longer needed or is being built elsewhere.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [style guidelines](https://silago.eecs.kth.se/docs/Guideline/Software/) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/silagokth/SiLagoDoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
