### PR TITLE
fix(vs-compile): extended MAX_LATENCY to 10 000 000

### DIFF
--- a/modules/vs-compile/src/tm/TimingModel.cpp
+++ b/modules/vs-compile/src/tm/TimingModel.cpp
@@ -2,7 +2,7 @@
 // or global variables at some point
 #define MAX_SLOTS 16
 #define NUM_PORTS_PER_RESOURCE 4
-#define MAX_LATENCY 100000
+#define MAX_LATENCY 10000000
 
 #include "tm/TimingModel.hpp"
 


### PR DESCRIPTION
This pull request increases the maximum allowed latency in the timing model, which may impact how timing constraints are handled in the system.

Timing configuration update:

* Increased `MAX_LATENCY` constant in `TimingModel.cpp` from 100,000 to 10,000,000 to allow for higher latency values.