### PR TITLE
fix(vs-compile): fixed a bug where ROP instructions might be scheduled non-consecutively; kept the old implementation under an `--allow-unsafe` flag arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,7 @@ Options:
 ### `vesyla compile`
 
 ```shell
-Usage: vesyla compile --arch FILE --isa FILE --pasm FILE [--output DIR]
-Or
-vesyla compile --arch FILE --isa FILE --cpp FILE [--output DIR]
+Usage: vesyla compile --arch FILE --isa FILE --pasm FILE [--output DIR] [--allow-unsafe]
 ```
 
 ## MLIR LSP Server for PASM

--- a/modules/vs-compile/src/exec/vs-compile/main.cpp
+++ b/modules/vs-compile/src/exec/vs-compile/main.cpp
@@ -1,5 +1,4 @@
 #include "schedule/Scheduler.hpp"
-#include "util/Common.hpp"
 #include <string>
 
 int main(int argc, char **argv) {
@@ -17,11 +16,12 @@ int main(int argc, char **argv) {
   args.parse(argc, argv);
 
   if (args.flag("h") || args.flag("help")) {
-    LOG_INFO << "Usage: vs-compile --arch FILE --isa FILE --pasm FILE "
-                "[--output DIR]";
-    LOG_INFO << "Or";
-    LOG_INFO << "vs-compile --arch FILE --isa FILE --cpp FILE "
-                "[--output DIR]";
+    LOG_INFO << "Usage: vesyla compile --arch FILE --isa FILE --pasm FILE "
+                "[--output DIR] [--allow-unsafe]";
+    // NOTE: commented this as not supported yet
+    // LOG_INFO << "Or";
+    // LOG_INFO << "vesyla compile --arch FILE --isa FILE --cpp FILE "
+    //             "[--output DIR]";
     return 0;
   }
 
@@ -30,6 +30,7 @@ int main(int argc, char **argv) {
   std::string pasm_file = args.get("pasm", args.get("p"));
   std::string cpp_file = args.get("cpp", args.get("c"));
   std::string output_dir = args.get("output", args.get("o", "."));
+  bool allow_unsafe = args.flag("allow-unsafe");
 
   if (arch_file.empty() || isa_file.empty()) {
     LOG_FATAL << "Required arguments missing, see --help for usage.";
@@ -69,7 +70,7 @@ int main(int argc, char **argv) {
   cfg.set_isa_json(isa_file);
 
   vesyla::schedule::Scheduler scheduler;
-  scheduler.run(pasm_file, output_dir);
+  scheduler.run(pasm_file, output_dir, allow_unsafe);
 
   // clean up temporary directories
   std::string temp_dir = vesyla::util::SysPath::temp_dir();

--- a/modules/vs-compile/src/pasm/Passes.td
+++ b/modules/vs-compile/src/pasm/Passes.td
@@ -10,7 +10,9 @@ def ScheduleEpochPass: Pass<"schedule-epoch-pass", "::mlir::ModuleOp"> {
   }];
   let options = [
     Option<"component_path", "component-path", "std::string", "\"\"", "">,
-    Option<"tmp_path", "tmp-path", "std::string", "\"\"", "">
+    Option<"tmp_path", "tmp-path", "std::string", "\"\"", "">,
+    Option<"allow_unsafe", "allow-unsafe", "bool", "false",
+      "Allow non-consecutive scheduling fallback if true">,
   ];
 }
 

--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -29,16 +29,18 @@ public:
   nlohmann::json component_map;
   std::string component_path;
   std::string tmp_path;
+  bool allow_unsafe;
   int _row;
   int _col;
 
 public:
   ScheduleEpochPassRewriter(MLIRContext *context, nlohmann::json component_map,
                             std::string component_path, std::string tmp_path,
-                            int row_, int col_)
+                            bool allow_unsafe, int row_, int col_)
       : OpRewritePattern<EpochOp>(context), component_map(component_map),
         component_path(std::move(component_path)),
-        tmp_path(std::move(tmp_path)), _row(row_), _col(col_) {}
+        tmp_path(std::move(tmp_path)), allow_unsafe(allow_unsafe), _row(row_),
+        _col(col_) {}
 
 private:
   mlir::Block *getOrCreateEntryBlock(mlir::Region &region,
@@ -682,12 +684,15 @@ private:
     } // end of erasing operations
   }
 
-  void insert_rop_instructions(
-      vector<mlir::Operation *> &rop_ops, int t, PatternRewriter &rewriter,
-      std::map<int, mlir::Operation *> &cell_time_table) const {
+  void
+  insert_rop_instructions(vector<mlir::Operation *> &rop_ops, int t,
+                          PatternRewriter &rewriter,
+                          std::map<int, mlir::Operation *> &cell_time_table,
+                          bool allow_unsafe = false) const {
+    // for each ROP
     for (auto op : rop_ops) {
       auto rop_op = llvm::dyn_cast<RopOp>(op);
-      int curr_t = t - 1;
+
       mlir::Region &ropBodyRegion = rop_op.getBody();
       mlir::Block *ropEntryBlock;
       if (ropBodyRegion.empty()) {
@@ -695,20 +700,57 @@ private:
       } else {
         ropEntryBlock = &ropBodyRegion.front();
       }
+
+      // gather instructions in the ROP body
       vector<mlir::Operation *> rop_child_ops;
       for (mlir::Operation &rop_child_op : *ropEntryBlock) {
-        rop_child_ops.push_back(&rop_child_op);
+        if (llvm::dyn_cast<InstrOp>(rop_child_op))
+          rop_child_ops.push_back(&rop_child_op);
       }
-      // reverse the order of the child operations
-      std::reverse(rop_child_ops.begin(), rop_child_ops.end());
-      for (auto rop_child_op : rop_child_ops) {
-        if (auto instr_op = llvm::dyn_cast<InstrOp>(rop_child_op)) {
-          while (cell_time_table.find(curr_t) != cell_time_table.end()) {
+      int num_instructions = rop_child_ops.size();
+      if (num_instructions == 0)
+        continue; // skip if there is no instruction in the ROP
+
+      // search for an empty time slot that is the size of the number of
+      // instructions in the ROP
+      int curr_t = t - 1;
+      bool found_slot = false;
+      while (!found_slot) {
+        found_slot = true;
+        for (int offset = 0; offset < num_instructions; offset++) {
+          int slot_t = curr_t - offset;
+          if (cell_time_table.find(slot_t) != cell_time_table.end()) {
+            found_slot = false;
+            curr_t = slot_t - 1;
+            break;
+          }
+        }
+      }
+
+      // if not found, reverse the order of the child operations
+      if (!found_slot && allow_unsafe) {
+        llvm::outs() << "Warning: Cannot find a safe time slot for ROP at time "
+                     << t
+                     << ". Inserting instructions in reverse order, which may"
+                        "cause hazards.\n";
+        std::reverse(rop_child_ops.begin(), rop_child_ops.end());
+        for (auto rop_child_op : rop_child_ops) {
+          if (auto instr_op = llvm::dyn_cast<InstrOp>(rop_child_op)) {
+            // while the current time slot is occupied, we keep moving backward
+            while (cell_time_table.find(curr_t) != cell_time_table.end()) {
+              curr_t--;
+            }
+            cell_time_table[curr_t] = rop_child_op;
             curr_t--;
           }
-          cell_time_table[curr_t] = rop_child_op;
-          curr_t--;
         }
+        continue;
+      }
+
+      // place instructions in consecutive time slots
+      for (int offset = 0; offset < num_instructions; offset++) {
+        int slot_t = curr_t - (num_instructions - 1) + offset;
+        cell_time_table[slot_t] = rop_child_ops[offset];
       }
     }
   }
@@ -869,7 +911,8 @@ private:
       first_reg = potential_first_reg + num_regs_needed;
     } else {
       llvm::outs()
-          << "Error: Cannot allocate registers for activation mode 2 at cycle "
+          << "Error: Cannot allocate registers for activation mode 2 at "
+             "cycle "
           << cycle
           << ". [r4->r7] and [r8->r11] are not available in controller.\n";
       exit(EXIT_FAILURE);
@@ -1078,7 +1121,7 @@ private:
 
   void synchronize(EpochOp &op,
                    std::unordered_map<std::string, int> &schedule_table,
-                   PatternRewriter &rewriter) const {
+                   PatternRewriter &rewriter, bool allow_unsafe = false) const {
 
     // Get the block to insert the new operations
     mlir::Block *block = getEpochBodyEntryBlock(op, rewriter);
@@ -1230,7 +1273,8 @@ private:
         std::string label = it->first;
         auto &cell_time_table = getOrCreateCellTimeTable(time_table, label);
         std::vector<mlir::Operation *> rop_ops = it->second;
-        insert_rop_instructions(rop_ops, t, rewriter, cell_time_table);
+        insert_rop_instructions(rop_ops, t, rewriter, cell_time_table,
+                                allow_unsafe);
       }
     }
 
@@ -1663,13 +1707,15 @@ public:
     nlohmann::json component_map_json = cfg.get_component_map_json();
     std::string component_path = this->component_path;
     std::string tmp_path = this->tmp_path;
+    bool allow_unsafe = this->allow_unsafe;
     nlohmann::json arch_json = cfg.get_arch_json();
     int row = arch_json["parameters"]["ROWS"].get<int>();
     int col = arch_json["parameters"]["COLS"].get<int>();
 
     RewritePatternSet patterns(&getContext());
     patterns.add<ScheduleEpochPassRewriter>(&getContext(), component_map_json,
-                                            component_path, tmp_path, row, col);
+                                            component_path, tmp_path,
+                                            allow_unsafe, row, col);
     FrozenRewritePatternSet patternSet(std::move(patterns));
     if (failed(applyPatternsGreedily(getOperation(), patternSet)))
       signalPassFailure();

--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -714,8 +714,7 @@ private:
   }
 
   void print_time_table(
-      std::unordered_map<string, std::map<int, mlir::Operation *>> &time_table)
-      const {
+      std::map<string, std::map<int, mlir::Operation *>> &time_table) const {
     // print the time table
     for (auto it = time_table.begin(); it != time_table.end(); ++it) {
       auto cell_label = it->first;
@@ -775,7 +774,7 @@ private:
   }
 
   std::map<int, mlir::Operation *> &getOrCreateCellTimeTable(
-      std::unordered_map<string, std::map<int, mlir::Operation *>> &time_table,
+      std::map<string, std::map<int, mlir::Operation *>> &time_table,
       const std::string &label) const {
     if (time_table.find(label) == time_table.end())
       time_table[label] = std::map<int, mlir::Operation *>();
@@ -1088,9 +1087,8 @@ private:
 
     // initialize the time_table and ordered_time_table, add the label for
     // every cell in the fabric
-    std::unordered_map<string, std::map<int, mlir::Operation *>> time_table;
-    std::unordered_map<string, std::vector<mlir::Operation *>>
-        ordered_time_table;
+    std::map<string, std::map<int, mlir::Operation *>> time_table;
+    std::map<string, std::vector<mlir::Operation *>> ordered_time_table;
     for (int r = 0; r < _row; r++) {
       for (int c = 0; c < _col; c++) {
         std::string label = std::to_string(r) + "_" + std::to_string(c);

--- a/modules/vs-compile/src/schedule/Scheduler.cpp
+++ b/modules/vs-compile/src/schedule/Scheduler.cpp
@@ -14,7 +14,8 @@ void Scheduler::save_mlir(mlir::ModuleOp &module, const std::string &filename) {
   ofs.close();
 }
 
-void Scheduler::run(std::string pasm_file, std::string output_dir) {
+void Scheduler::run(std::string pasm_file, std::string output_dir,
+                    bool allow_unsafe = false) {
   Parser parser;
   mlir::MLIRContext context;
   mlir::DialectRegistry registry;
@@ -25,10 +26,11 @@ void Scheduler::run(std::string pasm_file, std::string output_dir) {
       mlir::ModuleOp::create(mlir::UnknownLoc::get(&context));
   parser.parse(pasm_file, &module);
 
-  run(module, output_dir);
+  run(module, output_dir, allow_unsafe);
 }
 
-void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
+void Scheduler::run(mlir::ModuleOp &module, std::string output_dir,
+                    bool allow_unsafe = false) {
 
   // get the environment variable: VESYLA_SUITE_PATH_COMPONENTS
   std::string VESYLA_SUITE_PATH_COMPONENTS =
@@ -67,7 +69,7 @@ void Scheduler::run(mlir::ModuleOp &module, std::string output_dir) {
 
   std::string temp_dir = vesyla::util::SysPath::temp_dir();
   pm.addPass(vesyla::pasm::createScheduleEpochPass(
-      {VESYLA_SUITE_PATH_COMPONENTS, temp_dir}));
+      {VESYLA_SUITE_PATH_COMPONENTS, temp_dir, allow_unsafe}));
   if (mlir::failed(pm.run(module))) {
     LOG_FATAL << "Error: createScheduleEpochPass failed.\n";
     std::exit(EXIT_FAILURE);

--- a/modules/vs-compile/src/schedule/Scheduler.hpp
+++ b/modules/vs-compile/src/schedule/Scheduler.hpp
@@ -28,8 +28,8 @@ namespace schedule {
 class Scheduler {
 
 public:
-  void run(mlir::ModuleOp &module, std::string output_dir);
-  void run(std::string pasm_file, std::string output_dir);
+  void run(mlir::ModuleOp &module, std::string output_dir, bool allow_unsafe);
+  void run(std::string pasm_file, std::string output_dir, bool allow_unsafe);
 
 private:
   void save_mlir(mlir::ModuleOp &module, const std::string &filename);

--- a/modules/vs-compile/src/tm/TimingModel.cpp
+++ b/modules/vs-compile/src/tm/TimingModel.cpp
@@ -2,7 +2,7 @@
 // or global variables at some point
 #define MAX_SLOTS 16
 #define NUM_PORTS_PER_RESOURCE 4
-#define MAX_LATENCY 100000
+#define MAX_LATENCY 10000000
 
 #include "tm/TimingModel.hpp"
 


### PR DESCRIPTION
# fix(vs-compile): fixed a bug where ROP instructions might be scheduled non-consecutively; kept the old implementation under an `--allow-unsafe` flag arg

## Description

This pull request introduces an "allow unsafe scheduling" option to the vs-compile toolchain, enabling fallback to non-consecutive instruction scheduling when necessary. The change propagates a new `--allow-unsafe` flag from the command line through the scheduler and scheduling pass, and updates the scheduling logic to use this flag. Additionally, there are minor improvements and bug fixes throughout the codebase.

**Feature: Allow unsafe scheduling fallback**
- Added a new command-line flag `--allow-unsafe` to `vs-compile`, updated help text, and propagated the flag through the main entry point, scheduler, and scheduling pass. This enables users to allow non-consecutive scheduling when safe slots are unavailable. [[1]](diffhunk://#diff-455978e90f5895e2408783123be0f4af9f8c22ba0a7ccfda60d7f3ba431ef85fL20-R24) [[2]](diffhunk://#diff-455978e90f5895e2408783123be0f4af9f8c22ba0a7ccfda60d7f3ba431ef85fR33) [[3]](diffhunk://#diff-455978e90f5895e2408783123be0f4af9f8c22ba0a7ccfda60d7f3ba431ef85fL72-R73) [[4]](diffhunk://#diff-806273c0c1072a93fcec6984f00297a242da90e91f0b81c2d578b4621ecea9adL13-R15) [[5]](diffhunk://#diff-42d8004a8ea1aa97ac45ff9119f550d9c9404bfa5647b222a1fe3e653280bbdaL31-R32) [[6]](diffhunk://#diff-2c968623089bd9af60c196c146e1a22380e9c3534de938b25a034a85dde80dceL17-R18) [[7]](diffhunk://#diff-2c968623089bd9af60c196c146e1a22380e9c3534de938b25a034a85dde80dceL28-R33) [[8]](diffhunk://#diff-2c968623089bd9af60c196c146e1a22380e9c3534de938b25a034a85dde80dceL70-R72) [[9]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceR32-R43) [[10]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceR1710-R1718)

**Scheduling logic updates**
- Modified the `ScheduleEpochPassRewriter` to use the `allow_unsafe` flag: if no safe consecutive time slots are found for a ROP, and `allow_unsafe` is set, instructions are scheduled in reverse order with a warning. [[1]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceL685-R759) [[2]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceL1235-R1277)
- Updated time table and related data structures from `unordered_map` to `map` for deterministic ordering, and improved error and warning messages for scheduling and register allocation. [[1]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceL778-R819) [[2]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceL873-R915) [[3]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceL1082-R1124) [[4]](diffhunk://#diff-83509d94d63c5dd68273edcd9d29f63c4a1cba381ea1c684c2bd9e540f3f1eceL1091-R1134)

**Other improvements**
- Increased the `MAX_LATENCY` constant in the timing model to accommodate longer latency values.
- Removed an unused include from `main.cpp` for code cleanup.
