### PR TITLE
fix(schedule): epoch tail-wait off-by-one + op_end act-issue cycle

### DIFF
--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -1381,7 +1381,7 @@ private:
       if (prev_t != total_latency - 1) {
         rewriter.setInsertionPointToEnd(block);
         auto wait_instr_param_map =
-            create_wait_instr(total_latency - 1 - prev_t);
+            create_wait_instr(total_latency - 2 - prev_t);
         mlir::StringAttr id =
             rewriter.getStringAttr(vesyla::util::Common::gen_random_string(8));
         mlir::StringAttr type = rewriter.getStringAttr("wait");

--- a/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
+++ b/modules/vs-compile/src/pasm/ScheduleEpochPass.cpp
@@ -1343,6 +1343,8 @@ private:
                   return a.first < b.first;
                 });
 
+      // wait(N) consumes N+1 cycles (1 issue + N stall). Mid-gap fills
+      // curr_t - prev_t - 1 cycles, tail pads to total_latency.
       int prev_t = -1;
       std::vector<std::pair<int, mlir::Operation *>> new_time_op_vec;
       if (time_op_vec.size() > 0) {
@@ -1453,6 +1455,38 @@ private:
       // add a terminator to raw_op_block
       rewriter.setInsertionPointToEnd(raw_op_entry_block);
       rewriter.create<YieldOp>(raw_op->getLoc());
+
+      // Verifier: per-cell stream cycles must equal total_latency.
+      int stream_cycles = 0;
+      for (auto it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
+        auto instr_op = llvm::dyn_cast<vesyla::pasm::InstrOp>(*it2);
+        if (!instr_op) {
+          continue;
+        }
+        if (instr_op.getType() == "wait") {
+          mlir::DictionaryAttr params = instr_op.getParam();
+          int wait_n = 0;
+          if (params.contains("cycle")) {
+            if (auto int_attr = llvm::dyn_cast<mlir::IntegerAttr>(
+                    params.get("cycle"))) {
+              wait_n = int_attr.getInt();
+            }
+          }
+          stream_cycles += wait_n + 1;
+        } else {
+          stream_cycles += 1;
+        }
+      }
+      if (stream_cycles != total_latency) {
+        llvm::outs() << "Error: ScheduleEpochPass cell " << it->first
+                     << " stream cycles (" << stream_cycles
+                     << ") != total_latency (" << total_latency
+                     << "). Inter-cell sync broken — "
+                     << "check op duration_expr (multi-cycle ops like "
+                        "rep/act must reflect HW cycles in MZN) or wait "
+                        "param math.\n";
+        std::exit(EXIT_FAILURE);
+      }
     }
 
     // start from the end, remove everything after the first yield

--- a/modules/vs-compile/src/tm/TimingModel.cpp
+++ b/modules/vs-compile/src/tm/TimingModel.cpp
@@ -112,10 +112,12 @@ int TimingModel::to_mzn(std::ostream &mzn_file, std::ostream &dzn_file,
     mzn_file << "constraint op_start_vec[" +
                     std::to_string(op2idx[it->second.name]) +
                     "] == " + it->second.name + ";\n";
+    // +1 accounts for the act-issue controller cycle preceding background
+    // iteration; without it total_latency under-counts and halt fires mid-iter.
     mzn_file << "constraint op_end_vec[" +
                     std::to_string(op2idx[it->second.name]) +
                     "] == " + it->second.name + " + " +
-                    it->second.duration_expr + ";\n";
+                    it->second.duration_expr + " + 1;\n";
   }
 
   // add variables


### PR DESCRIPTION
## Summary
- Fix tail-wait overshoot in `ScheduleEpochPass::synchronize()`: `wait(N)` costs `N+1` cycles, so padding switched from `total_latency - 1 - prev_t` to `total_latency - 2 - prev_t`. Eliminates inter-cell drift accumulated across epochs by `MergeRawOp`.
- Fix `op_end` in `TimingModel` to include the controller cycle in which the rop's act instruction issues. Prevents halt from firing during the last AGU iteration.
- Add per-cell verifier in `ScheduleEpochPass` asserting stream cycles (`wait(N)=N+1`, others=1) equal `total_latency`. Catches future `duration_expr` / wait-formula regressions at compile time.

## Test plan
- [x] `drra-tests` drift detector clean on all multi-epoch cases (acc_vsquare_vmac, acc_seq, acc_vec, 1dconv_*_3_1, mmm/mvm_*_3_1, vector_*)
- [x] Repro `drra__basic__identity`: halt now at sim cycle 15, after AGU done
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)