### PR TITLE
ci: Tier A synthesizability lint (Verible + slang)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,3 +17,15 @@ jobs:
     with:
       version: ${{ needs.ci-build-vesyla.outputs.version }}
       branch: ${{ needs.ci-build-vesyla.outputs.branch }}
+
+  # Tier A: open-tool synthesizability lint (Verible + slang) on the fabric
+  # assembled by this build of vesyla. No PDK, GitHub-hosted, runs on every PR.
+  # Cheap complement to the gated Genus gate. See ci-synth-lint.yml.
+  ci-synth-lint:
+    name: Synthesizability lint
+    uses: ./.github/workflows/ci-synth-lint.yml
+    needs: ci-build-vesyla
+    secrets: inherit
+    with:
+      version: ${{ needs.ci-build-vesyla.outputs.version }}
+      branch: ${{ needs.ci-build-vesyla.outputs.branch }}

--- a/.github/workflows/ci-synth-lint.yml
+++ b/.github/workflows/ci-synth-lint.yml
@@ -1,0 +1,146 @@
+name: Synthesizability lint (Tier A)
+
+# Open-tool synthesizability check for the RTL emitted by THIS build of vesyla:
+# assemble a stdcell-only fabric and lint + elaborate it with Verible + slang on
+# a stock GitHub-hosted runner. No PDK, no self-hosted server — runs on every PR.
+# Cheap, broad complement to the gated Genus gate (ci-synth.yml). See
+# docs/SYNTH_LINT.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: vesyla version to fetch from pkg-artifacts (this run's build)
+        type: string
+        required: false
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      branch:
+        type: string
+        default: master
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Assemble + lint + elaborate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      APPIMAGE_EXTRACT_AND_RUN: 1   # run the vesyla AppImage without libfuse2
+    steps:
+      - name: Checkout vesyla (scripts + smoke arch)
+        uses: actions/checkout@v4
+
+      - name: Install Verible
+        run: |
+          set -e
+          url=$(curl -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest \
+                | jq -r '.assets[].browser_download_url' \
+                | grep -E 'linux-static-x86_64\.tar\.gz$' | head -1)
+          [ -n "$url" ] || { echo "no Verible linux asset found"; exit 1; }
+          echo "Verible: $url"
+          curl -fsSL "$url" -o verible.tar.gz
+          mkdir -p "$HOME/verible"
+          tar -xzf verible.tar.gz -C "$HOME/verible" --strip-components=1
+          echo "$HOME/verible/bin" >> "$GITHUB_PATH"
+
+      - name: Install slang (best-effort prebuilt)
+        continue-on-error: true
+        run: |
+          set -e
+          url=$(curl -fsSL https://api.github.com/repos/MikePopoloski/slang/releases/latest \
+                | jq -r '.assets[].browser_download_url' \
+                | grep -iE 'linux.*(x86_64|amd64).*(tar\.gz|zip)$' | head -1)
+          if [ -z "$url" ]; then
+            echo "No slang prebuilt linux asset published; skipping (verible remains the baseline)."
+            exit 0
+          fi
+          echo "slang: $url"
+          mkdir -p "$HOME/slang"
+          case "$url" in
+            *.zip) curl -fsSL "$url" -o slang.zip && unzip -q slang.zip -d "$HOME/slang" ;;
+            *)     curl -fsSL "$url" -o slang.tgz && tar -xzf slang.tgz -C "$HOME/slang" ;;
+          esac
+          bindir=$(dirname "$(find "$HOME/slang" -type f -name slang | head -1)")
+          [ -n "$bindir" ] && echo "$bindir" >> "$GITHUB_PATH" || echo "slang binary not located in archive"
+
+      - name: Install gh CLI
+        run: |
+          curl -sS https://webi.sh/gh | sh
+          source ~/.config/envman/PATH.env
+          gh --version
+
+      - name: Download DRRA components library
+        run: |
+          set -e
+          source ~/.config/envman/PATH.env
+          BRANCH="${{ inputs.branch }}"
+          REPO="silagokth/drra-components"
+          rm -f library.tar.gz
+          if [ -n "$BRANCH" ] && gh api "repos/$REPO/branches/$BRANCH" >/dev/null 2>&1; then
+            RUN_ID=$(gh run list --repo "$REPO" --branch "$BRANCH" \
+                       --workflow "PR workflow" --status success \
+                       --limit 1 --json databaseId -q '.[0].databaseId')
+            if [ -n "$RUN_ID" ]; then
+              gh run download "$RUN_ID" --repo "$REPO" -n library -D .
+            fi
+          fi
+          if [ ! -f library.tar.gz ]; then
+            gh release download --repo "$REPO" --pattern "library.tar.gz"
+          fi
+          [ -f library.tar.gz ] || { echo "library.tar.gz not found"; exit 1; }
+        env:
+          GITHUB_TOKEN: ${{ secrets.DRRA_COMPONENTS_PAT_VESYLA_READ_ONLY }}
+
+      - name: Extract library
+        run: |
+          rm -rf library
+          tar -xzf library.tar.gz
+          rm library.tar.gz
+
+      - name: Get built vesyla artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pkg-artifacts
+          path: ${{ github.workspace }}/artifacts
+
+      - name: Install vesyla
+        run: |
+          set -e
+          file=("$GITHUB_WORKSPACE"/artifacts/vesyla-*.AppImage)
+          [ "${#file[@]}" -eq 1 ] || { echo "Expected one AppImage, got ${#file[@]}"; exit 1; }
+          cp "${file[0]}" vesyla
+          chmod a+x vesyla
+          mkdir -p "$HOME/.local/bin"
+          mv vesyla "$HOME/.local/bin/"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Assemble stdcell-only fabric
+        run: |
+          set -e
+          export VESYLA_SUITE_PATH_COMPONENTS="$(readlink -e library)"
+          vesyla --version
+          vesyla component assemble -i scripts/synth/arch_smoke_no_sram.json -o build
+          ls -R build/rtl/fabric
+
+      - name: Lint + elaborate fabric
+        run: |
+          fab="$(find build -type f -path '*/rtl/fabric/Bender.yml' -printf '%h\n' | head -1)"
+          [ -n "$fab" ] || { echo "no generated fabric found"; exit 1; }
+          rtl_root="$(dirname "$fab")"
+          TOP=fabric bash scripts/synth/lint_fabric.sh "$rtl_root" | tee lint.log
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo '### Tier A synthesizability lint'
+            echo '```'
+            tail -n 40 lint.log 2>/dev/null || echo '(no lint output)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-synth-lint.yml
+++ b/.github/workflows/ci-synth-lint.yml
@@ -49,25 +49,19 @@ jobs:
           tar -xzf verible.tar.gz -C "$HOME/verible" --strip-components=1
           echo "$HOME/verible/bin" >> "$GITHUB_PATH"
 
-      - name: Install slang (best-effort prebuilt)
-        continue-on-error: true
+      - name: Install slang
         run: |
           set -e
           url=$(curl -fsSL https://api.github.com/repos/MikePopoloski/slang/releases/latest \
                 | jq -r '.assets[].browser_download_url' \
-                | grep -iE 'linux.*(x86_64|amd64).*(tar\.gz|zip)$' | head -1)
-          if [ -z "$url" ]; then
-            echo "No slang prebuilt linux asset published; skipping (verible remains the baseline)."
-            exit 0
-          fi
+                | grep -iE 'linux-x86_64\.tar\.gz$' | head -1)
+          [ -n "$url" ] || { echo "no slang linux asset found"; exit 1; }
           echo "slang: $url"
-          mkdir -p "$HOME/slang"
-          case "$url" in
-            *.zip) curl -fsSL "$url" -o slang.zip && unzip -q slang.zip -d "$HOME/slang" ;;
-            *)     curl -fsSL "$url" -o slang.tgz && tar -xzf slang.tgz -C "$HOME/slang" ;;
-          esac
-          bindir=$(dirname "$(find "$HOME/slang" -type f -name slang | head -1)")
-          [ -n "$bindir" ] && echo "$bindir" >> "$GITHUB_PATH" || echo "slang binary not located in archive"
+          mkdir -p "$HOME/slang/bin"
+          curl -fsSL "$url" -o slang.tgz
+          tar -xzf slang.tgz -C "$HOME/slang/bin"   # tarball is a bare `slang` binary
+          chmod +x "$HOME/slang/bin/slang"
+          echo "$HOME/slang/bin" >> "$GITHUB_PATH"
 
       - name: Install gh CLI
         run: |
@@ -125,7 +119,7 @@ jobs:
           set -e
           export VESYLA_SUITE_PATH_COMPONENTS="$(readlink -e library)"
           vesyla --version
-          vesyla component assemble -i scripts/synth/arch_smoke_no_sram.json -o build
+          vesyla component assemble --arch-json scripts/synth/arch_smoke_no_sram.json --output build
           ls -R build/rtl/fabric
 
       - name: Lint + elaborate fabric

--- a/docs/SYNTH_LINT.md
+++ b/docs/SYNTH_LINT.md
@@ -1,0 +1,65 @@
+# Synthesizability lint — Tier A (open tools, no PDK)
+
+The cheap, broad half of the synthesizability strategy, on the vesyla side.
+Assembles a stdcell-only fabric with the freshly-built vesyla from the PR and
+lints + elaborates it with **open tools only** (Verible + slang) on a stock
+GitHub-hosted runner. No PDK, no liberty, no self-hosted server — runs on
+**every PR**.
+
+It mirrors the same Tier A gate in `drra-components`; that one guards RTL
+changes, this one guards **vesyla** changes. Either can break the composed
+fabric. It is the complement to the gated Genus gate (`docs/SYNTH_CI.md`), which
+is the authoritative PDK area/Fmax sign-off.
+
+## What it does
+
+```
+ci-synth-lint.yml (ubuntu-latest, every PR, after ci-build-vesyla)
+  ├─ install Verible (required) + slang (best-effort prebuilt)
+  ├─ download the drra-components `library` (branch artifact or release, via gh)
+  ├─ install the vesyla AppImage built in THIS run (pkg-artifacts)
+  ├─ vesyla component assemble -i scripts/synth/arch_smoke_no_sram.json -o build
+  │     (pure RTL composition — no solver, no simulation, top module `fabric`)
+  └─ scripts/synth/lint_fabric.sh build/rtl
+```
+
+`vesyla component assemble` is the bare composition path (no minizinc / no
+QuestaSim), which is why this works on a vanilla runner. The input
+`scripts/synth/arch_smoke_no_sram.json` is a minimal 1×1 **no-SRAM** fabric
+(swb + io + 3×rf + dpu on `cell_single_row`), so it is stdcell-only and needs no
+SRAM macro.
+
+## What it catches
+
+| Tool | Check | Severity |
+|------|-------|----------|
+| `verible-verilog-syntax` | parse breakage from templating / bad SV | hard fail |
+| `verible-verilog-lint` | style + a few structural rules (`scripts/synth/verible.rules`) | soft (hard if `STRICT=1`) |
+| `slang --top fabric` | full elaboration: unresolved modules, port/width mismatches, and — because the RTL uses `always_comb` — incomplete-assignment **latches** | hard fail (when slang present) |
+
+slang natively elaborates the `agu_cfg_if` SystemVerilog interfaces that plain
+Yosys cannot. It is best-effort: if no prebuilt binary is published, the step
+skips with a notice and Verible remains the guaranteed baseline.
+
+## Relationship to Tier B (Genus)
+
+| | Tier A (this) | Tier B (`ci-synth.yml`) |
+|--|--------------|--------------------------|
+| Runner | GitHub-hosted | self-hosted w/ PDK server |
+| PDK | none | GF22 (server-side only) |
+| Catches | synth-construct breakage, latches | + real area / Fmax |
+| Runs | every PR | gated (label + environment) |
+
+## Local run
+
+```sh
+export VESYLA_SUITE_PATH_COMPONENTS=/path/to/built/library
+vesyla component assemble -i scripts/synth/arch_smoke_no_sram.json -o build
+bash scripts/synth/lint_fabric.sh build/rtl       # STRICT=1 to enforce lint too
+```
+
+## Notes / first-run
+
+- The AppImage runs via `APPIMAGE_EXTRACT_AND_RUN=1` (no libfuse2 on the runner).
+- If slang's prebuilt asset naming changes, adjust the grep in the install step.
+- Uses existing secret `DRRA_COMPONENTS_PAT_VESYLA_READ_ONLY` for the library.

--- a/scripts/synth/arch_smoke_no_sram.json
+++ b/scripts/synth/arch_smoke_no_sram.json
@@ -1,0 +1,51 @@
+{
+  "platform": "drra",
+  "resources": [
+    { "name": "swb_impl", "kind": "swb" },
+    { "name": "io_impl", "kind": "io" },
+    { "name": "rf_impl", "kind": "rf" },
+    { "name": "dpu_impl", "kind": "dpu" }
+  ],
+  "controllers": [
+    { "name": "sequencer_impl", "kind": "sequencer" }
+  ],
+  "cells": [
+    {
+      "name": "cell_single_row_impl",
+      "kind": "cell_single_row",
+      "controller": "sequencer_impl",
+      "resource_list": [
+        "swb_impl",
+        "io_impl",
+        "rf_impl",
+        "rf_impl",
+        "rf_impl",
+        "dpu_impl"
+      ]
+    }
+  ],
+  "fabric": {
+    "height": 1,
+    "width": 1,
+    "cells_list": [
+      { "coordinates": [ { "row": 0, "col": 0 } ], "cell_name": "cell_single_row_impl" }
+    ],
+    "custom_properties": [
+      { "name": "IO_DATA_WIDTH", "value": 256 },
+      { "name": "IO_ADDR_WIDTH", "value": 16 },
+      { "name": "RESOURCE_INSTR_WIDTH", "value": 27 },
+      { "name": "ROWS", "value": 1 },
+      { "name": "COLS", "value": 1 },
+      { "name": "INSTR_DATA_WIDTH", "value": 32 },
+      { "name": "INSTR_ADDR_WIDTH", "value": 8 },
+      { "name": "INSTR_HOPS_WIDTH", "value": 4 },
+      { "name": "INSTR_OPCODE_BITWIDTH", "value": 3 },
+      { "name": "INSTR_PAYLOAD_BITWIDTH", "value": 27 },
+      { "name": "BULK_WIDTH", "value": 256 }
+    ]
+  },
+  "interface": {
+    "input_buffer_depth": 1024,
+    "output_buffer_depth": 1024
+  }
+}

--- a/scripts/synth/lint_fabric.sh
+++ b/scripts/synth/lint_fabric.sh
@@ -29,17 +29,27 @@ RTL_ROOT="${1:?usage: lint_fabric.sh <fabric_rtl_root>}"
 TOP="${TOP:-fabric}"
 STRICT="${STRICT:-0}"
 
-mapfile -t SV < <(find "$RTL_ROOT" -type f -name '*.sv' | sort)
+# Build the synthesizable file set. `vesyla component assemble` copies the whole
+# common/ library (incl. all three sram.{sim,gf22,tsmc28}.sv variants, which each
+# define `module sram`) and the testbenches, regardless of what the fabric
+# actually instantiates. For a no-SRAM fabric the sram macro is never wired in,
+# so exclude it (keeping it would feed slang three duplicate `sram` modules).
+# Also exclude testbenches and the AGU self-test files (sim-only, not synth).
+mapfile -t SV < <(find "$RTL_ROOT" -type f -name '*.sv' \
+  -not -path '*/common/sram/*' \
+  -not -path '*/test/*' \
+  -not -path '*/tb/*' | sort)
 if [[ ${#SV[@]} -eq 0 ]]; then
   echo "ERROR: no .sv files under $RTL_ROOT" >&2
   exit 2
 fi
-echo "==> ${#SV[@]} SystemVerilog files under $RTL_ROOT (top=$TOP)"
+echo "==> ${#SV[@]} SystemVerilog files (top=$TOP, sram/tb/test excluded)"
 
-# Stay stdcell-only: a real SRAM macro would need the confidential lib and is
-# out of scope for the open lint gate.
-if find "$RTL_ROOT" -path '*/common/sram/*' -name '*.sv' | grep -q .; then
-  echo "ERROR: fabric pulls in common/sram — Tier A expects a no-SRAM fabric." >&2
+# Stay stdcell-only: assert the fabric cone does not *instantiate* the sram
+# macro (an iosram fabric would, and that needs the confidential GF22 SRAM lib).
+if grep -lE '^[[:space:]]*sram[[:space:]]+(#|[A-Za-z_])' "${SV[@]}" >/dev/null 2>&1; then
+  echo "ERROR: fabric instantiates the sram macro — not stdcell-only." >&2
+  echo "       Tier A expects a no-SRAM (io) fabric." >&2
   exit 4
 fi
 

--- a/scripts/synth/lint_fabric.sh
+++ b/scripts/synth/lint_fabric.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# lint_fabric.sh — Tier A synthesizability check: lint + elaborate an assembled
+# DRRA fabric with OPEN tools only. No PDK, no liberty, no server — safe to run
+# on a stock GitHub-hosted runner on every PR.
+#
+# What it catches (PDK-independent, the bulk of "did this break synthesis"):
+#   * verible-verilog-syntax — parse breakage from templating / bad SV (hard).
+#   * verible-verilog-lint   — style / a few synthesis-relevant rules (soft;
+#                              hard when STRICT=1).
+#   * slang elaboration      — full SystemVerilog elaboration of the `fabric`
+#                              top, natively handling the agu_cfg_if interfaces
+#                              that plain Yosys cannot. Flags unresolved modules,
+#                              port/width mismatches, and — because the RTL is
+#                              written with always_comb — incomplete-assignment
+#                              latches. Hard fail on errors (when slang present).
+#
+# slang is treated as best-effort: if the binary is not on PATH the check is
+# skipped with a notice (verible remains the guaranteed baseline). Install slang
+# in the workflow to activate elaboration + latch checks.
+#
+# Usage: lint_fabric.sh <fabric_rtl_root>      # e.g. build/rtl
+#   env TOP    top module name      (default: fabric)
+#   env STRICT 1 => verible lint warnings are fatal too (default: 0)
+#
+set -euo pipefail
+
+RTL_ROOT="${1:?usage: lint_fabric.sh <fabric_rtl_root>}"
+TOP="${TOP:-fabric}"
+STRICT="${STRICT:-0}"
+
+mapfile -t SV < <(find "$RTL_ROOT" -type f -name '*.sv' | sort)
+if [[ ${#SV[@]} -eq 0 ]]; then
+  echo "ERROR: no .sv files under $RTL_ROOT" >&2
+  exit 2
+fi
+echo "==> ${#SV[@]} SystemVerilog files under $RTL_ROOT (top=$TOP)"
+
+# Stay stdcell-only: a real SRAM macro would need the confidential lib and is
+# out of scope for the open lint gate.
+if find "$RTL_ROOT" -path '*/common/sram/*' -name '*.sv' | grep -q .; then
+  echo "ERROR: fabric pulls in common/sram — Tier A expects a no-SRAM fabric." >&2
+  exit 4
+fi
+
+fail=0
+
+# 1. Verible syntax — hard gate (catches templating/parse breakage). -----------
+if command -v verible-verilog-syntax >/dev/null 2>&1; then
+  echo "== verible-verilog-syntax =="
+  verible-verilog-syntax "${SV[@]}" || fail=1
+else
+  echo "WARN: verible-verilog-syntax not found; skipping syntax check"
+fi
+
+# 2. Verible lint — soft by default (style-heavy), fatal under STRICT. ----------
+if command -v verible-verilog-lint >/dev/null 2>&1; then
+  echo "== verible-verilog-lint =="
+  rules=()
+  [[ -f "$(dirname "$0")/verible.rules" ]] && rules=(--rules_config "$(dirname "$0")/verible.rules")
+  if verible-verilog-lint "${rules[@]}" "${SV[@]}"; then
+    echo "lint: clean"
+  else
+    if [[ "$STRICT" == "1" ]]; then fail=1; else echo "(lint warnings — non-fatal; set STRICT=1 to enforce)"; fi
+  fi
+else
+  echo "WARN: verible-verilog-lint not found; skipping lint"
+fi
+
+# 3. slang elaboration — hard gate when present (interfaces, latches, widths). --
+if command -v slang >/dev/null 2>&1; then
+  echo "== slang elaborate (top=$TOP) =="
+  # --top forces hierarchy elaboration from `fabric`; errors -> non-zero exit.
+  slang --top "$TOP" --error-limit=100 "${SV[@]}" || fail=1
+else
+  echo "WARN: slang not found; skipping elaboration (latch/interface/width checks)."
+  echo "      Install slang in the workflow to enable the full Tier A gate."
+fi
+
+if [[ "$fail" == "0" ]]; then
+  echo "Tier A synthesizability lint PASSED"
+else
+  echo "Tier A synthesizability lint FAILED"
+  exit 1
+fi

--- a/scripts/synth/verible.rules
+++ b/scripts/synth/verible.rules
@@ -1,0 +1,24 @@
+# Verible lint rules for the Tier A synthesizability gate.
+# Goal: surface substance, suppress pure-style noise on generated RTL.
+# Format: one `+rule` / `-rule` per line. See `verible-verilog-lint --help_rules`.
+
+# --- silence high-noise / generated-code-unfriendly style rules ---
+-line-length
+-no-trailing-spaces
+-posix-eof
+-explicit-parameter-storage-type
+-parameter-name-style
+-module-filename
+-package-filename-system
+
+# --- keep substance: structural / lint rules worth enforcing ---
++case-missing-default
++always-comb
++always-comb-blocking
++always-ff-non-blocking
++enum-name-style
++generate-label
++module-begin-block
++packed-dimensions-range-ordering
++suspicious-semicolon
++undersized-binary-literal

--- a/scripts/synth/verible.rules
+++ b/scripts/synth/verible.rules
@@ -1,24 +1,25 @@
 # Verible lint rules for the Tier A synthesizability gate.
-# Goal: surface substance, suppress pure-style noise on generated RTL.
-# Format: one `+rule` / `-rule` per line. See `verible-verilog-lint --help_rules`.
+# Goal: surface substance, suppress style noise inherent to generated RTL.
+# Format: one `+rule` / `-rule` per line. Validate names with
+#   verible-verilog-lint --help_rules=all
+# (an invalid name makes Verible discard the whole file and fall back to defaults).
 
-# --- silence high-noise / generated-code-unfriendly style rules ---
+# --- silence noise that generated/fingerprinted RTL always trips ---
 -line-length
 -no-trailing-spaces
 -posix-eof
 -explicit-parameter-storage-type
 -parameter-name-style
--module-filename
--package-filename-system
+-module-filename                       # module name carries a fingerprint, file does not
+-macro-name-style                      # `define names are fingerprinted (lowercase)
+-package-filename                      # package name is fingerprinted vs the file name
+-unpacked-dimensions-range-ordering    # generated [N] unpacked dims
 
-# --- keep substance: structural / lint rules worth enforcing ---
+# --- keep substance ---
 +case-missing-default
-+always-comb
-+always-comb-blocking
-+always-ff-non-blocking
 +enum-name-style
-+generate-label
-+module-begin-block
-+packed-dimensions-range-ordering
 +suspicious-semicolon
 +undersized-binary-literal
++always-comb
++always-ff-non-blocking
++forbid-line-continuations


### PR DESCRIPTION
## What
Mirror of the drra-components Tier A gate, guarding **vesyla** changes: on every
PR it assembles a stdcell-only fabric with the freshly-built vesyla and
elaborates it with Verible + slang on a GitHub-hosted runner. Wired as
`ci-synth-lint` (needs `ci-build-vesyla`). New files:
`.github/workflows/ci-synth-lint.yml`,
`scripts/synth/{lint_fabric.sh, arch_smoke_no_sram.json, verible.rules}`,
`docs/SYNTH_LINT.md`.

## Why
A vesyla change can break the synthesizability of the RTL it emits even when the
RTL templates are unchanged. This catches that with no PDK and no self-hosted
server. drra-components guards the RTL; this guards the tool.

## Testing
Flow validated locally against a real assembled fabric.

> ⚠️ This gate consumes the drra-components library, so its slang step will fail
> on `swb/controller.sv:136` (a nested-default assignment pattern) until the fix
> is released in drra-components (silagokth/drra-components#124). Expect this
> check to be red until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)