### PR TITLE
feat(vs-testcase): validate SST vs RTL cycle count in run.sh

### DIFF
--- a/modules/vs-testcase/template/drra/run.sh
+++ b/modules/vs-testcase/template/drra/run.sh
@@ -268,6 +268,36 @@ fi
 set -e
 stop_spinner 0
 
+# Timing validation: the instruction-level (SST) and RTL models must agree on
+# the realized cycle count. Both simulators write it to a file every run: the
+# SST controller writes `instr_sim_cycles.txt` (_currentSSTCycle/10) at
+# teardown, the RTL testbench writes `rtl_sim_cycles.txt`. A mismatch means the
+# compiler schedule, the SST model and the RTL hardware disagree on timing.
+printf "${BOLD}Timing:${NC} SST (instruction-level) vs RTL cycle count\n"
+start_spinner
+printf "  ${BLUE}Verifying${NC} (SST == RTL)"
+sst_cycles=""
+rtl_cycles=""
+if [ -f "instr_sim_cycles.txt" ]; then
+  sst_cycles=$(tr -d '[:space:]' <instr_sim_cycles.txt)
+fi
+rtl_cycles_file=$(find archive -name 'rtl_sim_cycles.txt' 2>/dev/null | head -1)
+if [ -n "$rtl_cycles_file" ] && [ -f "$rtl_cycles_file" ]; then
+  rtl_cycles=$(tr -d '[:space:]' <"$rtl_cycles_file")
+fi
+if [ -z "$sst_cycles" ] || [ -z "$rtl_cycles" ]; then
+  stop_spinner 1
+  printf " ${RED}-> ERROR:${NC} cycle count missing (SST='%s' RTL='%s')\n" "${sst_cycles:-N/A}" "${rtl_cycles:-N/A}"
+  exit 1
+fi
+if [ "$sst_cycles" -ne "$rtl_cycles" ]; then
+  stop_spinner 1
+  printf " ${RED}-> ERROR:${NC} cycle mismatch: SST=%s RTL=%s (diff=%s)\n" "$sst_cycles" "$rtl_cycles" "$((rtl_cycles - sst_cycles))"
+  exit 1
+fi
+stop_spinner 0
+printf "  ${CYAN}%s${NC} cycles (SST == RTL)\n" "$sst_cycles"
+
 printf "\n${GREEN}All models executed successfully!${NC}\n\n"
 
 cat <<"EOF"


### PR DESCRIPTION
## What

Add a **timing validation step** to the drra testcase `run.sh`. Both simulators already write their realized cycle count to a file every run (SST → `instr_sim_cycles.txt`, RTL → `rtl_sim_cycles.txt`). The step reads both and **fails the run on a mismatch** (or a missing file).

## Why

The existing checks only compare the sram output buffers (`model_0` vs SST vs RTL data). A schedule- or simulation-timing regression that still produced correct data would pass silently. This closes that blind spot by asserting the compiler schedule, the SST model and the RTL hardware agree on cycle count.

## Depends on

silagokth/drra-components#129 — with the RTL testbench reporting the halt-execution cycle, `SST == RTL` holds across all passing testcases. Without it, the step trips on the constant +1 (registered `ret_all`) offset.

## Verification

Ran the full drra testcase suite via `vesyla testcase run` (using this template). All 31 functionally-passing testcases report `SST == RTL` (diff 0), range 56–4158 cycles, 1-cell and 3-cell, iosram and io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)